### PR TITLE
Updates for deprecated appdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 `tootgroup.py` - emulate group accounts on Mastodon and Pleroma
 =================================================
 
@@ -87,7 +89,7 @@ It is also possible to download the script manually from the GitHub repository a
 have to be provided too:
 
 `tootgroup.py` requires <https://github.com/halcy/Mastodon.py> as well as
-<https://github.com/ActiveState/appdirs> to run. Install them via your
+<https://pypi.org/project/platformdirs> to run. Install them via your
 operating system's package manager, pip or even manually.
 
 `tootgroup.py` will guide you through setup by asking all information it needs

--- a/tootgroup_tools/configuration_management.py
+++ b/tootgroup_tools/configuration_management.py
@@ -5,7 +5,7 @@ import configparser
 import os
 import sys
 
-import appdirs
+import platformdirs
 import mastodon
 
 
@@ -244,7 +244,7 @@ def setup_configuration_store():
     config_store["filename"] = config_filename
 
     local_path = application_path
-    os_user_config_path = appdirs.AppDirs(application_name).user_data_dir + "/"
+    os_user_config_path = platformdirs.user_data_dir(application_name) + "/"
     config_store["directory"] = local_path
 
     # Is there a config file in the tootgroup.py directory?


### PR DESCRIPTION
The appdirs module is deprecated.  A suggested replacement is platformdirs

https://pypi.org/project/platformdirs/

